### PR TITLE
Enabling exclusion of identifiersProductId from elastic search aggregation

### DIFF
--- a/src/Finder/RelatedProductsCombinedFinder.php
+++ b/src/Finder/RelatedProductsCombinedFinder.php
@@ -51,7 +51,7 @@ class RelatedProductsCombinedFinder extends AbstractRelatedProductsFinder implem
             $locale,
             $slug,
             $maxResults,
-            $excludedProductIds = [],
+            $excludedProductIds,
         );
 
         if (count($relatedProducts) >= $maxResults) {


### PR DESCRIPTION
- Fix misassigned $excludedProductsId in Combined finder 
- Enabling exclusion of identifiersProductId from elastic search aggregation